### PR TITLE
Use correct runtime and function name for custom authorizer

### DIFF
--- a/src/createAuthScheme.js
+++ b/src/createAuthScheme.js
@@ -22,9 +22,8 @@ module.exports = function createAuthScheme(authFun, authorizerOptions, funName, 
     identityHeader = identitySourceMatch[1].toLowerCase();
   }
 
-  const funOptions = functionHelper.getFunctionOptions(authFun, funName, servicePath);
-
   const serviceRuntime = serverless.service.provider.runtime;
+  const funOptions = functionHelper.getFunctionOptions(authFun, authFunName, servicePath, serviceRuntime);
 
   // Create Auth Scheme
   return () => ({
@@ -105,7 +104,7 @@ module.exports = function createAuthScheme(authFun, authorizerOptions, funName, 
         }
 
         const onSuccess = policy => {
-        // Validate that the policy document has the principalId set
+          // Validate that the policy document has the principalId set
           if (!policy.principalId) {
             serverlessLog(`Authorization response did not include a principalId: (λ: ${authFunName})`, err);
 


### PR DESCRIPTION
I have a custom authorizer for a function:

`  test_authenticate:
    description: Function that requires authentication.
    handler: auth.authentication.test_authenticate
    module: auth
    events:
      - http:
          path: test_authenticate
          method: get
          authorizer: authenticate

  authenticate:
    description: AWS Custom Authorizer for authenticating.
    handler: auth.authentication.authenticate
    module: auth
`

However, the authorizer function does not get called - instead the actual function is called, because it's name is used. Passing the authorizer funtion name and runtime fixes the issue. Or maybe my configuration is invalid? :)